### PR TITLE
A few fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: triebeard
 Type: Package
 Title: 'Radix' Trees in 'Rcpp'
-Version: 0.2.0
+Version: 0.2.1
 Author: Oliver Keyes [aut, cre], Drew Schmidt [aut], Yuuki Takano [cph]
 Maintainer: Oliver Keyes <ironholds@gmail.com>
 Description: 'Radix trees', or 'tries', are key-value data structures optimised for efficient lookups, similar in purpose

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 0.2.1
+=================================
+BUG FIXES
+* Fixed segfault when `trie_remove()` resulted in a 0 element trie.
+
 Version 0.2.0
 =================================
 FEATURES

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -40,5 +40,7 @@ str.trie <- function(object, ...){
 
 #'@export
 print.trie <- function(x, ...){
-  cat("A", class(x)[3], "object with", length(x), "entries\n")
+  len <- length(x)
+  entry_word <- ifelse(len != 1, "entries", "entry")
+  cat("A", class(x)[3], "object with", len, entry_word, "\n")
 }

--- a/src/alter.cpp
+++ b/src/alter.cpp
@@ -19,9 +19,7 @@ void add_trie_string(SEXP trie, CharacterVector keys, CharacterVector values){
 //[[Rcpp::export]]
 void add_trie_integer(SEXP trie, CharacterVector keys, IntegerVector values){
   r_trie <int>* rt_ptr = (r_trie <int> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   unsigned int in_size = keys.size();
   for(unsigned int i = 0; i < in_size; i++){
     if((i % 10000) == 0){
@@ -37,9 +35,7 @@ void add_trie_integer(SEXP trie, CharacterVector keys, IntegerVector values){
 //[[Rcpp::export]]
 void add_trie_numeric(SEXP trie, CharacterVector keys, NumericVector values){
   r_trie <double>* rt_ptr = (r_trie <double> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   unsigned int in_size = keys.size();
   for(unsigned int i = 0; i < in_size; i++){
     if((i % 10000) == 0){
@@ -55,9 +51,7 @@ void add_trie_numeric(SEXP trie, CharacterVector keys, NumericVector values){
 //[[Rcpp::export]]
 void add_trie_logical(SEXP trie, CharacterVector keys, LogicalVector values){
   r_trie <bool>* rt_ptr = (r_trie <bool> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   unsigned int in_size = keys.size();
   for(unsigned int i = 0; i < in_size; i++){
     if((i % 10000) == 0){
@@ -73,35 +67,27 @@ void add_trie_logical(SEXP trie, CharacterVector keys, LogicalVector values){
 //[[Rcpp::export]]
 void remove_trie_string(SEXP trie, CharacterVector keys){
   r_trie <std::string>* rt_ptr = (r_trie <std::string> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   rt_ptr->remove_values(keys);
 }
 
 //[[Rcpp::export]]
 void remove_trie_integer(SEXP trie, CharacterVector keys){
   r_trie <int>* rt_ptr = (r_trie <int> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   rt_ptr->remove_values(keys);
 }
 
 //[[Rcpp::export]]
 void remove_trie_numeric(SEXP trie, CharacterVector keys){
   r_trie <double>* rt_ptr = (r_trie <double> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   rt_ptr->remove_values(keys);
 }
 
 //[[Rcpp::export]]
 void remove_trie_logical(SEXP trie, CharacterVector keys){
   r_trie <bool>* rt_ptr = (r_trie <bool> *) R_ExternalPtrAddr(trie);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
   rt_ptr->remove_values(keys);
 }

--- a/src/prefix_match.cpp
+++ b/src/prefix_match.cpp
@@ -37,9 +37,7 @@ List prefix_string(SEXP radix, CharacterVector to_match){
 //[[Rcpp::export]]
 List prefix_integer(SEXP radix, CharacterVector to_match){
   r_trie <int>* rt_ptr = (r_trie <int> *) R_ExternalPtrAddr(radix);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
 
   unsigned int input_size = to_match.size();
   List output(input_size);
@@ -71,9 +69,7 @@ List prefix_integer(SEXP radix, CharacterVector to_match){
 //[[Rcpp::export]]
 List prefix_numeric(SEXP radix, CharacterVector to_match){
   r_trie <double>* rt_ptr = (r_trie <double> *) R_ExternalPtrAddr(radix);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
 
   unsigned int input_size = to_match.size();
   List output(input_size);
@@ -105,9 +101,7 @@ List prefix_numeric(SEXP radix, CharacterVector to_match){
 //[[Rcpp::export]]
 List prefix_logical(SEXP radix, CharacterVector to_match){
   r_trie <bool>* rt_ptr = (r_trie <bool> *) R_ExternalPtrAddr(radix);
-  if (rt_ptr == NULL){
-    stop("invalid trie object; pointer is NULL");
-  }
+  ptr_check(rt_ptr);
 
   unsigned int input_size = to_match.size();
   List output(input_size);

--- a/src/r_trie.h
+++ b/src/r_trie.h
@@ -17,7 +17,7 @@ class r_trie {
   public:
 
     int size(){
-      return std::distance(radix.begin(), radix.end());
+      return radix.size();
     }
 
     radix_tree<std::string, T> radix;
@@ -75,6 +75,7 @@ class r_trie {
           radix.erase(Rcpp::as<std::string>(keys[i]));
         }
       }
+      
       radix_size = size();
     }
 };


### PR DESCRIPTION
* Replaced the custom `size()` calculation in class `r_trie` to use the `size()` method from class `radix_tree`. This seems to solve https://github.com/Ironholds/triebeard/issues/6 and all other current tests are passing.
* Use `ptr_check()` when possible.
* Improved grammar in the print method.